### PR TITLE
Disallow --include_dir with --stage or --oii

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ gradergen.egg-info/
 
 # For testing
 pip_modules/
+testing/**/*.out
+testing/**/*.md5
+testing/**/*grader*
+testing/**/*template*

--- a/gradergen/grader_generator.py
+++ b/gradergen/grader_generator.py
@@ -244,6 +244,10 @@ def main():
     if args.all:
         args.languages = [[lang] for lang in LANGUAGES_LIST]
 
+    if args.stage or args.oii:
+        if args.include_dir is not None:
+            raise ValueError("--include_dir is not supported with --stage or "
+                             "--oii, use gradergen/.")
 
     if args.stage:
         args.include_dir = "gradergen"

--- a/testing/include_callable_test/.gitignore
+++ b/testing/include_callable_test/.gitignore
@@ -1,0 +1,2 @@
+input.txt
+nome_sorgente_contestantlib.pas


### PR DESCRIPTION
`--stage` and `--oii` override the `--include_dir` flag. Using both is now an error:
```
$ gradergen --stage fast --include_dir asdassad

ValueError: --include_dir is not supported with --stage or --oii, use gradergen/
```

Those flags also set the language set, so `--all` should be incompatible as well, but `argparse` already prevent this:
```
$ gradergen --stage fast --all

usage: gradergen [-h] [--task_spec [task_spec]] [--task_yaml [task_yaml]] [--include_dir [include_dir]] [--debug] (-l lang [filename ...] | -a | --oii | --stage [IO_type])
gradergen: error: argument -a/--all: not allowed with argument --stage
```

----

This PR also adds to the gitignore the test artifacts.
